### PR TITLE
Added mention of double parsing and extended reject reason

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -109,8 +109,9 @@ special file ending. Several file endings have been discussed, in the end
 The content would be pre-parsed to identify whether its a `CommonJS` or
 `ES2015` module.
 
-_(Rejected because the detection has ambiguity in `CommonJS` packages. This could be revisited if the TC39 changes the specification of ES2015 modules but
-could still be rejected because of performance reasons)_
+_(Rejected because the detection has ambiguity in `CommonJS` packages. This
+**could** be revisited if the TC39 changes the spec, but - for a variety of  
+other reasons - it is likely to still be rejected)_
 
 [more here](https://github.com/nodejs/node/wiki/ES6-Module-Detection-in-Node#option-3-content-sniffing-in-node-semantics-rejected)
 

--- a/readme.md
+++ b/readme.md
@@ -104,7 +104,7 @@ special file ending. Several file endings have been discussed, in the end
 
 [more here](https://github.com/nodejs/node/wiki/ES6-Module-Detection-in-Node#option-2-new-file-extension-for-es6-modules)
 
-### 3) ~~Content-Sniffing~~ _(rejected)_
+### 3) ~~Content-Sniffing aka. Double Parsing~~ _(rejected)_
 
 The content would be pre-parsed to identify whether its a `CommonJS` or
 `ES2015` module.

--- a/readme.md
+++ b/readme.md
@@ -109,7 +109,8 @@ special file ending. Several file endings have been discussed, in the end
 The content would be pre-parsed to identify whether its a `CommonJS` or
 `ES2015` module.
 
-_(Rejected because the detection is fuzzy and could lead to user confusion and problems with tooling)_
+_(Rejected because the detection has ambiguity in `CommonJS` packages. This could be revisited if the TC39 changes the specification of ES2015 modules but
+could still be rejected because of performance reasons)_
 
 [more here](https://github.com/nodejs/node/wiki/ES6-Module-Detection-in-Node#option-3-content-sniffing-in-node-semantics-rejected)
 


### PR DESCRIPTION
Following the suggestions of @mikesherov in #12 this PR adds a better explanation of double parsing to the content-sniffing.
